### PR TITLE
Add ability to not spam slack too much

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 *.retry
+.idea

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ MIT / BSD
 ## Sponsored by
 
 #### [Kwiziq.com](https://www.kwiziq.com) - The AI language education platform
-#### [Spottmedia Ltd.](http://www.spottmedia.com) - Technology design, delivery and consulting
+#### [Spottmedia.com](http://www.spottmedia.com) - Technology design, delivery and consulting
 
 ## Author Information
 

--- a/README.md
+++ b/README.md
@@ -26,6 +26,12 @@ ssh_login_notifications_slack_enable: false
 
 # Set the Slack custom integration webhook URL
 ssh_login_notifications_slack_webhook: ""
+
+# Keep track of IPs that logged in and only report to slack if a new one logs in
+# NOTE: There isn't an email conterpart since normally you want your email log to be as detailed as possible
+# for better forensic analysis
+# Seen IPs' log is kept as a plaintext file under /var/log/ansible-ssh-login-notification.log
+ssh_login_notifications_slack_only_unique: true
 ```
 
 Notifications previously activated with this role can be deactivated by setting the variable to *false*. 

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ MIT / BSD
 
 ## Author Information
 
-python, ansible & shell coding done by [Grzegorz Nowak](https://www.linkedin.com/in/grzegorz-nowak-356b7360/) and Spottmedia.
+python, ansible, slack & shell coding by [Grzegorz Nowak](https://www.linkedin.com/in/grzegorz-nowak-356b7360/) and Spottmedia.
 
 
 the initial code was a fork from a work of:

--- a/README.md
+++ b/README.md
@@ -45,13 +45,19 @@ None
 ```
 - hosts: server
   roles:
-    - { role: membrive.ssh-login-notifications }
+    - { role: grzegorznowak.ansible_role_ssh_login_notifications }
 ```
 
 ## License
 
 MIT / BSD
 
+## Sponsored by
+
+#### Kwiziq.com 
+#### Spottmedia.com
+
 ## Author Information
 
-This role was created in 2017 by [Fernando Membrive](https://membrive.net).
+This is a fork from a work of:
+[Fernando Membrive](https://membrive.net).

--- a/README.md
+++ b/README.md
@@ -54,8 +54,8 @@ MIT / BSD
 
 ## Sponsored by
 
-#### Kwiziq.com 
-#### Spottmedia.com
+[Kwiziq.com](https://www.kwiziq.com)
+[Spottmedia Ltd.](https://www.spottmedia.com)
 
 ## Author Information
 

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ MIT / BSD
 
 ## Author Information
 
-python, ansible & shell coding done by Grzegorz Nowak and Spottmedia.
+python, ansible & shell coding done by [Grzegorz Nowak](https://www.linkedin.com/in/grzegorz-nowak-356b7360/) and Spottmedia.
 
 
 the initial code was a fork from a work of:

--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
 # Ansible Role: SSH Login Notifications
 
-[![Build Status](https://travis-ci.org/membrive/ansible-role-ssh-login-notifications.svg?branch=master)](https://travis-ci.org/membrive/ansible-role-ssh-login-notifications)
 
 Installs scripts to send a notification (by mail and/or Slack) when an user logs in using SSH.
 

--- a/README.md
+++ b/README.md
@@ -53,8 +53,8 @@ MIT / BSD
 
 ## Sponsored by
 
-#### [Kwiziq.com](https://www.kwiziq.com)
-#### [Spottmedia Ltd.](http://www.spottmedia.com)
+#### [Kwiziq.com](https://www.kwiziq.com) - The AI language education platform
+#### [Spottmedia Ltd.](http://www.spottmedia.com) - Technology design, delivery and consulting
 
 ## Author Information
 

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ MIT / BSD
 ## Sponsored by
 
 #### [Kwiziq.com](https://www.kwiziq.com)
-#### [Spottmedia Ltd.](https://www.spottmedia.com)
+#### [Spottmedia Ltd.](http://www.spottmedia.com)
 
 ## Author Information
 

--- a/README.md
+++ b/README.md
@@ -54,8 +54,8 @@ MIT / BSD
 
 ## Sponsored by
 
-[Kwiziq.com](https://www.kwiziq.com)
-[Spottmedia Ltd.](https://www.spottmedia.com)
+#### [Kwiziq.com](https://www.kwiziq.com)
+#### [Spottmedia Ltd.](https://www.spottmedia.com)
 
 ## Author Information
 

--- a/README.md
+++ b/README.md
@@ -56,7 +56,11 @@ MIT / BSD
 #### [Kwiziq.com](https://www.kwiziq.com) - The AI language education platform
 #### [Spottmedia.com](http://www.spottmedia.com) - Technology design, delivery and consulting
 
+
 ## Author Information
 
-This is a fork from a work of:
+python, ansible & shell coding done by Grzegorz Nowak and Spottmedia.
+
+
+the initial code was a fork from a work of:
 [Fernando Membrive](https://membrive.net).

--- a/templates/send_slack_on_ssh_login.sh.j2
+++ b/templates/send_slack_on_ssh_login.sh.j2
@@ -3,22 +3,35 @@ if [ "$PAM_TYPE" != "open_session" ]
 then
   exit 0
 else
-  URL={{ ssh_login_notifications_slack_webhook }}
-  TEXT=$(echo -e "$PAM_SERVICE login on `hostname -s` for account *$PAM_USER* ($PAM_TTY)\n" | python -c "import json,sys;print(json.dumps(sys.stdin.read()))")
-  PAYLOAD="{
-    \"attachments\": [
-      {
-        \"text\": $TEXT,
-        \"color\": \"danger\",
-        \"mrkdwn_in\": [\"text\"],
-        \"fields\": [
-          { \"title\": \"Date\", \"value\": \"`date`\", \"short\": true },
-          { \"title\": \"Host\", \"value\": \"$PAM_RHOST\", \"short\": true }
-        ]
-      }
-    ]
-  }"
+  {% if ssh_login_notifications_slack_only_unique is defined and ssh_login_notifications_slack_only_unique == true %}
+  LOG_FILE="/var/log/ansible-ssh-login-notification.log"
+  WORD=$PAM_RHOST
+  if [[ "$WORD" =~ $(echo ^\($(paste -sd'|' $LOG_FILE)\)$) ]]; then
+      echo "$WORD is already on the list, no need to notify anyone"
+  else
+  {% endif %}
+    URL={{ ssh_login_notifications_slack_webhook }}
+    TEXT=$(echo -e "$PAM_SERVICE login on `hostname -s` for account *$PAM_USER* ($PAM_TTY)\n" | python -c "import json,sys;print(json.dumps(sys.stdin.read()))")
+    PAYLOAD="{
+      \"attachments\": [
+        {
+          \"text\": $TEXT,
+          \"color\": \"danger\",
+          \"mrkdwn_in\": [\"text\"],
+          \"fields\": [
+            { \"title\": \"Date\", \"value\": \"`date`\", \"short\": true },
+            { \"title\": \"Host\", \"value\": \"$PAM_RHOST\", \"short\": true }
+          ]
+        }
+      ]
+    }"
 
-  curl -s -X POST --data-urlencode "payload=$PAYLOAD" $URL
+    curl -s -X POST --data-urlencode "payload=$PAYLOAD" $URL
+  {% if ssh_login_notifications_slack_only_unique is defined and ssh_login_notifications_slack_only_unique == true %}
+    echo "$WORD" >> $LOG_FILE
+  fi
+  {% endif %}
+
+
 fi
 exit 0


### PR DESCRIPTION
Hey man!
We have so many servers and robot processes accessing those, that it made sense to add a flag to not flood slack with each and every SSH login.
After all, what we really care about is seeing if there isn't anything unknown that gets it's way through.
Hope it turns to be helpful for everyone!